### PR TITLE
ci(cd_pr): bypass kuberc actions/cache@v2

### DIFF
--- a/.github/workflows/cd_pr.yml
+++ b/.github/workflows/cd_pr.yml
@@ -35,10 +35,17 @@ jobs:
 
       - run: kubectl kustomize ${{ matrix.overlay }} > .kuberc-input
 
+      # Install Deno without MarkArts/kuberc's actions/cache@v2 step (deprecated by GitHub).
+      - if: steps.overlay_exists.outcome == 'success'
+        uses: denoland/setup-deno@v1
+        with:
+          deno-version: v1.x
+
       - if: steps.overlay_exists.outcome == 'success'
         uses: MarkArts/kuberc/.github/actions/kuberc@main
         with:
           file: .kuberc-input
+          deno_install: "false"
           extra_args: |
             --skip-secrets rabbitmq-connection,newrelic-licence,rds-secret \
             --skip-configmaps s3-configmap,stripeout-elasticache,shitcoins-elasticache,gus-elasticache,entrails-elasticache,stripe-adapter-elasticache,dummy-psp-elasticache,rumen-elasticache,openhaggler-elasticache \


### PR DESCRIPTION
## Summary
GitHub fails PR jobs that touch `actions/cache@v2`. The MarkArts/kuberc composite action still uses `actions/cache@v2` when `deno_install` is true (default).

This PR installs Deno via `denoland/setup-deno@v1` and passes `deno_install: false` to kuberc so the deprecated cache step is skipped while behaviour stays the same.

## Verification
Consumers (e.g. entrails `cd.yml` calling `GETProtocolLab/workflows/.github/workflows/cd_pr.yml@master`) pick this up after merge.


Made with [Cursor](https://cursor.com)