### PR TITLE
ci(cd_pr): skip argocd_diff for PRs targeting development

### DIFF
--- a/.github/workflows/cd_pr.yml
+++ b/.github/workflows/cd_pr.yml
@@ -53,7 +53,15 @@ jobs:
 
   argocd_diff:
     runs-on: [self-hosted, ubuntu20.04-self]
-    if: github.base_ref  == 'development' || github.base_ref  == 'master' || github.base_ref  == 'production'
+    # NOTE: 'development' base is intentionally excluded.
+    # The testing ArgoCD instance at https://argocd.euc1.t.get-protocol.dev
+    # is currently unreachable (HTTP 503) — there is no live server for the
+    # diff to query, so the job would fail on every PR targeting development.
+    # Production ArgoCD (https://argocd.euc1.get-protocol.cloud) is healthy
+    # and the diff still gates PRs targeting master and production.
+    # When the testing cluster is restored, add `github.base_ref == 'development' ||`
+    # back to the condition below.
+    if: github.base_ref == 'master' || github.base_ref == 'production'
     steps:
       - id: argocd
         shell: bash


### PR DESCRIPTION
## Summary

The reusable \`argocd_diff\` job currently runs on PRs targeting \`development\`, \`master\`, and \`production\`. For the **development** base, it calls the testing ArgoCD at \`https://argocd.euc1.t.get-protocol.dev\` — which is **currently down** (HTTP 503 from the browser, HTML returned instead of JSON in the action).

This breaks every PR opened against \`development\` across every repo consuming this reusable workflow:
- [GETProtocolLab/message-service#158](https://github.com/GETProtocolLab/message-service/pull/158)
- [GETProtocolLab/entrails#1828](https://github.com/GETProtocolLab/entrails/pull/1828)
- [GETProtocolLab/entrails#1829](https://github.com/GETProtocolLab/entrails/pull/1829)
- [GETProtocolLab/entrails#1830](https://github.com/GETProtocolLab/entrails/pull/1830)

Example failure: \`FetchError: invalid json response body ... reason: Unexpected token '<', "<html>\` — the standard signature of an ingress returning an error page in place of API JSON.

## Change

Remove \`development\` from the job's \`if:\` condition. The job still runs on PRs targeting \`master\` (staging ArgoCD) and \`production\` (production ArgoCD, verified healthy via working \`deploy-argocd\` jobs).

A comment is added in-place explaining why and how to revert when the testing cluster is restored.

## What this does NOT change

- Production deploys: \`push_workflow / deploy-argocd\` continues to gate prod and uses the healthy production ArgoCD.
- Master/staging diff visibility: still runs.
- The bash branch handling \`GIT_REF == "development"\` inside the job is left intact for easy revert.

## Test plan

- [ ] After merge, re-run CI on the open dev-base PRs above; the \`argocd_diff\` check should report as skipped instead of failed.
- [ ] Verify a master- or production-base PR still triggers \`argocd_diff\` (no behavior change there).

## Follow-up (not in scope of this PR)

The testing ArgoCD being down is a separate infrastructure issue worth investigating — owners of \`deployments\` / \`k8seks\` / \`terraform\` would know whether it was decommissioned intentionally or is broken. When restored, revert the if condition per the inline comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)